### PR TITLE
restore parent window if valid

### DIFF
--- a/lua/glance/init.lua
+++ b/lua/glance/init.lua
@@ -335,6 +335,9 @@ function Glance:update_preview(item)
 end
 
 function Glance:close()
+  if vim.api.nvim_win_is_valid(self.parent_winnr) then
+      vim.api.nvim_set_current_win(self.parent_winnr)
+  end
   vim.api.nvim_del_augroup_by_name('Glance')
   self.list:close()
   self.preview:close()


### PR DESCRIPTION
This fixes an issue when using glance.nvim and nvim-ide. 

It appears that glance did not try to restore the window to the original one it was invoked from on close. 

This caused a few issues:

1. When closing glance you'd wind up in an nvim-ide component window.
2. Even worse, when using a jump or split+jump you'd perform this in the component window. 

Looks like we can restore the "parent_winnr" on close if its valid to avoid this issue.