### PR TITLE
feat(list): add ability to cycle list

### DIFF
--- a/lua/glance/init.lua
+++ b/lua/glance/init.lua
@@ -202,11 +202,11 @@ Glance.actions = {
     glance:update_preview(item)
   end,
   next_location = function()
-    local item = glance.list:next({ loc_only = true })
+    local item = glance.list:next({ loc_only = true, cycle = true })
     glance:update_preview(item)
   end,
   previous_location = function()
-    local item = glance.list:previous({ loc_only = true })
+    local item = glance.list:previous({ loc_only = true, cycle = true })
     glance:update_preview(item)
   end,
   preview_scroll_win = function(distance)

--- a/lua/glance/list.lua
+++ b/lua/glance/list.lua
@@ -370,13 +370,12 @@ end
 
 function List:next(opts)
   opts = opts or {}
-  for i in
+  for i, item in
     self:walk({
       start = self:get_line() + (opts.offset or 0),
       cycle = opts.cycle,
     })
   do
-    local item = self.items[i]
     if opts.loc_only and item.is_file and folds.is_folded(item.filename) then
       self:toggle_fold(item)
       return self:next({

--- a/lua/glance/list.lua
+++ b/lua/glance/list.lua
@@ -356,12 +356,13 @@ end
 function List:walk(opts)
   local idx = opts.start
   return function()
+    local line_count = vim.api.nvim_buf_line_count(self.bufnr)
     idx = idx + (opts.backwards and -1 or 1)
     if opts.cycle then
-      idx = ((idx - 1) % vim.api.nvim_buf_line_count(self.bufnr)) + 1
+      idx = ((idx - 1) % line_count) + 1
     end
     local item = self.items[idx]
-    if not item then
+    if not item or idx > line_count then
       return nil
     end
     return idx, item

--- a/lua/glance/list.lua
+++ b/lua/glance/list.lua
@@ -371,7 +371,7 @@ function List:next(opts)
   opts = opts or {}
   for i, item in
     self:walk({
-      start = self:get_line() + (opts.skip or 0),
+      start = self:get_line(),
       step_increment = 1,
       cycle = opts.cycle,
     })
@@ -393,7 +393,7 @@ function List:previous(opts)
   opts = opts or {}
   for i, item in
     self:walk({
-      start = self:get_line() + (opts.skip or 0),
+      start = self:get_line(),
       step_increment = -1,
       cycle = opts.cycle,
     })

--- a/lua/glance/list.lua
+++ b/lua/glance/list.lua
@@ -402,9 +402,10 @@ function List:previous(opts)
     })
   do
     if opts.loc_only and item.is_file and folds.is_folded(item.filename) then
+      local is_last_line = i == vim.api.nvim_buf_line_count(self.bufnr)
       self:toggle_fold(item)
       return self:previous({
-        offset = item.count, -- offset by how many new items were added after unfolding
+        offset = is_last_line and 0 or item.count, -- offset by how many new items were added after unfolding
         cycle = opts.cycle,
         loc_only = true,
       })

--- a/lua/glance/list.lua
+++ b/lua/glance/list.lua
@@ -352,17 +352,36 @@ function List:get_current_item()
   return item
 end
 
+---@param opts { start: integer, step_increment: integer, cycle?: boolean }
+function List:walk(opts)
+  local idx = opts.start
+  return function()
+    idx = idx + opts.step_increment
+    if opts.cycle then
+      idx = ((idx - 1) % vim.api.nvim_buf_line_count(self.bufnr)) + 1
+    end
+    if not self.items[idx] then
+      return nil
+    end
+    return idx, self.items[idx]
+  end
+end
+
 function List:next(opts)
   opts = opts or {}
-  for i = self:get_line() + 1 + (opts.skip or 0), vim.api.nvim_buf_line_count(self.bufnr), 1 do
-    local item = self.items[i]
-    if item and opts.loc_only and item.is_file then
+  for i, item in
+    self:walk({
+      start = self:get_line() + (opts.skip or 0),
+      step_increment = 1,
+      cycle = opts.cycle,
+    })
+  do
+    if opts.loc_only and item.is_file then
       if folds.is_folded(item.filename) then
         self:toggle_fold(item)
       end
-      return self:next({ skip = 1 })
     end
-    if item and not (opts.loc_only and item.is_file) then
+    if not (opts.loc_only and item.is_file) then
       vim.api.nvim_win_set_cursor(self.winnr, { i, self:get_col() })
       return item
     end
@@ -372,16 +391,19 @@ end
 
 function List:previous(opts)
   opts = opts or {}
-  for i = self:get_line() - 1 + (opts.skip or 0), 0, -1 do
-    local item = self.items[i]
-    if item and opts.loc_only and item.is_file then
+  for i, item in
+    self:walk({
+      start = self:get_line() + (opts.skip or 0),
+      step_increment = -1,
+      cycle = opts.cycle,
+    })
+  do
+    if opts.loc_only and item.is_file then
       if folds.is_folded(item.filename) then
         self:toggle_fold(item)
-        return self:previous({ skip = item.count - 1 })
       end
-      return self:previous({ skip = -1, loc_only = true })
     end
-    if item and not (opts.loc_only and item.is_file) then
+    if not (opts.loc_only and item.is_file) then
       vim.api.nvim_win_set_cursor(self.winnr, { i, self:get_col() })
       return item
     end

--- a/lua/glance/list.lua
+++ b/lua/glance/list.lua
@@ -352,34 +352,38 @@ function List:get_current_item()
   return item
 end
 
----@param opts { start: integer, step_increment: integer, cycle?: boolean }
+---@param opts { start: integer, backwards?: boolean, cycle?: boolean }
 function List:walk(opts)
   local idx = opts.start
   return function()
-    idx = idx + opts.step_increment
+    idx = idx + (opts.backwards and -1 or 1)
     if opts.cycle then
       idx = ((idx - 1) % vim.api.nvim_buf_line_count(self.bufnr)) + 1
     end
-    if not self.items[idx] then
+    local item = self.items[idx]
+    if not item then
       return nil
     end
-    return idx, self.items[idx]
+    return idx, item
   end
 end
 
 function List:next(opts)
   opts = opts or {}
-  for i, item in
+  for i in
     self:walk({
-      start = self:get_line(),
-      step_increment = 1,
+      start = self:get_line() + (opts.offset or 0),
       cycle = opts.cycle,
     })
   do
-    if opts.loc_only and item.is_file then
-      if folds.is_folded(item.filename) then
-        self:toggle_fold(item)
-      end
+    local item = self.items[i]
+    if opts.loc_only and item.is_file and folds.is_folded(item.filename) then
+      self:toggle_fold(item)
+      return self:next({
+        offset = i - self:get_line(), -- offset by how far we've already iterated prior to unfolding
+        cycle = opts.cycle,
+        loc_only = true,
+      })
     end
     if not (opts.loc_only and item.is_file) then
       vim.api.nvim_win_set_cursor(self.winnr, { i, self:get_col() })
@@ -393,15 +397,18 @@ function List:previous(opts)
   opts = opts or {}
   for i, item in
     self:walk({
-      start = self:get_line(),
-      step_increment = -1,
+      start = self:get_line() + (opts.offset or 0),
       cycle = opts.cycle,
+      backwards = true,
     })
   do
-    if opts.loc_only and item.is_file then
-      if folds.is_folded(item.filename) then
-        self:toggle_fold(item)
-      end
+    if opts.loc_only and item.is_file and folds.is_folded(item.filename) then
+      self:toggle_fold(item)
+      return self:previous({
+        offset = item.count, -- offset by how many new items were added after unfolding
+        cycle = opts.cycle,
+        loc_only = true,
+      })
     end
     if not (opts.loc_only and item.is_file) then
       vim.api.nvim_win_set_cursor(self.winnr, { i, self:get_col() })


### PR DESCRIPTION
This changes the `List:next()` and `List:previous()` implementations to use a custom
iterator that has the ability to cycle the underlying list.

Closes #27.
