### PR TITLE
fix(winbar): check win is valid before setting 'winbar'

### DIFF
--- a/lua/glance/winbar.lua
+++ b/lua/glance/winbar.lua
@@ -32,7 +32,9 @@ function Winbar:render(section_values)
 
   self.last_values = section_values
   vim.schedule(function()
-    vim.api.nvim_win_set_option(self.winnr, 'winbar', winbar_value)
+    if vim.api.nvim_win_is_valid(self.winnr) then
+      vim.api.nvim_win_set_option(self.winnr, 'winbar', winbar_value)
+    end
   end)
 end
 


### PR DESCRIPTION
This fixes an issue where the window may have been closed by the time
the scheduled callback is invoked, causing an error such as:

```
Error executing vim.schedule lua callback: ...site/pack/packer/start/glance.nvim/lua/glance/winbar.lua:34: Invalid window id: 1014
stack traceback:
        [C]: in function 'nvim_win_set_option'
        ...site/pack/packer/start/glance.nvim/lua/glance/winbar.lua:34: in function <...site/pack/packer/start/glance.nvim/lua/
```
