### PR TITLE
feat(list): add folding actions

### DIFF
--- a/lua/glance/init.lua
+++ b/lua/glance/init.lua
@@ -314,6 +314,15 @@ Glance.actions = {
     Glance.setup()
     open({ method = method })
   end,
+  toggle_fold = function()
+    glance:toggle_fold()
+  end,
+  open_fold = function()
+    glance:toggle_fold(true)
+  end,
+  close_fold = function()
+    glance:toggle_fold(false)
+  end,
 }
 
 function Glance:create(opts)
@@ -424,6 +433,19 @@ function Glance:jump(opts)
   vim.cmd('norm! zz')
 
   self:destroy()
+end
+
+function Glance:toggle_fold(expand)
+  local item = self.list:get_current_item()
+  if not item or item.is_unreachable then
+    return
+  end
+  if expand == nil then
+    return self.list:toggle_fold(item)
+  elseif expand then
+    return self.list:open_fold(item)
+  end
+  return self.list:close_fold(item)
 end
 
 function Glance:update_preview(item)

--- a/lua/glance/list.lua
+++ b/lua/glance/list.lua
@@ -592,4 +592,14 @@ function List:toggle_fold(item)
   self:update(self.groups)
 end
 
+function List:open_fold(item)
+  folds.open(item.filename)
+  self:update(self.groups)
+end
+
+function List:close_fold(item)
+  folds.close(item.filename)
+  self:update(self.groups)
+end
+
 return List


### PR DESCRIPTION
Adds `toggle_fold`, `open_fold` and `close_fold` actions.

Example usage:

```lua
mappings = {
  list = {
    ['h'] = actions.close_fold,
    ['l'] = actions.open_fold,
  },
},
```