### PR TITLE
fix: error when inlay hints attempt to disable on close

### DIFF
--- a/lua/glance/preview.lua
+++ b/lua/glance/preview.lua
@@ -174,6 +174,7 @@ function Preview:close()
 
   for _, bufnr in ipairs(touched_buffers) do
     if vim.api.nvim_buf_is_valid(bufnr) and vim.fn.buflisted(bufnr) ~= 1 then
+      pcall(vim.lsp.inlay_hint, bufnr, false)
       vim.api.nvim_buf_delete(bufnr, { force = true })
     else
       clear_hl(bufnr)


### PR DESCRIPTION
Appeared after https://github.com/neovim/neovim/pull/24411
When a preview window is closed neovim prints this error:

```
Error executing lua callback: ...im-linux64/share/nvim/runtime/lua/vim/lsp/inlay_hint.lua:126: Failed to delete autocmd
stack traceback:
	[C]: in function 'nvim_del_autocmd'
	...im-linux64/share/nvim/runtime/lua/vim/lsp/inlay_hint.lua:126: in function 'disable'
	...im-linux64/share/nvim/runtime/lua/vim/lsp/inlay_hint.lua:162: in function <...im-linux64/share/nvim/runtime/lua/vim/lsp/inlay_hint.lua:161>
	[C]: in function 'nvim_buf_delete'
	...local/share/nvim/lazy/glance.nvim/lua/glance/preview.lua:178: in function 'close'
	...e/.local/share/nvim/lazy/glance.nvim/lua/glance/init.lua:502: in function 'close'
	...e/.local/share/nvim/lazy/glance.nvim/lua/glance/init.lua:244: in function <...e/.local/share/nvim/lazy/glance.nvim/lua/glance/init.lua:243>
```
We can fix this error by manually disabling inlay hints before deleting a preview buffer.
`pcall` is used for backwards compatibility: AFAIK stable neovim does not have `inlay_hint` yet.