### PR TITLE
fix: add false variant to mappings annotations

### DIFF
--- a/lua/glance/config.lua
+++ b/lua/glance/config.lua
@@ -19,8 +19,8 @@ config.hl_ns = 'Glance'
 ---@field mode ('"brighten"' | '"darken"' | '"auto"')
 
 ---@class GlanceMappingsOpts
----@field list table<string, fun()>
----@field preview table<string, fun()>
+---@field list table<string, fun()|false>
+---@field preview table<string, fun()|false>
 
 ---@class GlanceHooksOpts
 ---@field before_open fun(results: table[], open: fun(locations: table[]), jump: fun(location: table), method: GlanceMethod)


### PR DESCRIPTION
Without `false`  variant `lua-ls` complains that it cannot assign `boolean` to `fun()`.
But in fact `false` is actually a valid key to disable a key mapping.