### PR TITLE
refactor: better way to detect inlay_hint

### DIFF
--- a/lua/glance/preview.lua
+++ b/lua/glance/preview.lua
@@ -174,7 +174,9 @@ function Preview:close()
 
   for _, bufnr in ipairs(touched_buffers) do
     if vim.api.nvim_buf_is_valid(bufnr) and vim.fn.buflisted(bufnr) ~= 1 then
-      pcall(vim.lsp.inlay_hint, bufnr, false)
+      if vim.lsp.inlay_hint then
+        vim.lsp.inlay_hint(bufnr, false)
+      end
       vim.api.nvim_buf_delete(bufnr, { force = true })
     else
       clear_hl(bufnr)

--- a/lua/glance/preview.lua
+++ b/lua/glance/preview.lua
@@ -174,7 +174,7 @@ function Preview:close()
 
   for _, bufnr in ipairs(touched_buffers) do
     if vim.api.nvim_buf_is_valid(bufnr) and vim.fn.buflisted(bufnr) ~= 1 then
-      if vim.fn.has('nvim-0.10') == 1 then
+      if vim.fn.has('nvim-0.9.2') == 1 then
         vim.lsp.inlay_hint(bufnr, false)
       end
       vim.api.nvim_buf_delete(bufnr, { force = true })

--- a/lua/glance/preview.lua
+++ b/lua/glance/preview.lua
@@ -174,7 +174,7 @@ function Preview:close()
 
   for _, bufnr in ipairs(touched_buffers) do
     if vim.api.nvim_buf_is_valid(bufnr) and vim.fn.buflisted(bufnr) ~= 1 then
-      if vim.lsp.inlay_hint then
+      if vim.fn.has('nvim-0.10') == 1 then
         vim.lsp.inlay_hint(bufnr, false)
       end
       vim.api.nvim_buf_delete(bufnr, { force = true })


### PR DESCRIPTION
I haven't given it a thorough thought before but we don't want to use `pcall` because it hides potential errors on neovim's side.

This is a much better way to detect if `inlay_hint` function exists.

Sorry for the noise!