### PR TITLE
feat: option to not open quickfix window on respective action

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ glance.setup({
       ['q'] = actions.close,
       ['Q'] = actions.close,
       ['<Esc>'] = actions.close,
-      ['<C-q>'] = actions.quickfix,
+      ['<C-q>'] = actions.quickfix, -- `actions.quickfix("no-open")` to not open the quickfix window afterward
       -- ['<Esc>'] = false -- disable a mapping
     },
     preview = {

--- a/lua/glance/init.lua
+++ b/lua/glance/init.lua
@@ -323,7 +323,8 @@ Glance.actions = {
     Glance.setup()
     open({ method = method, hooks = opts and opts.hooks })
   end,
-  quickfix = function()
+    ---@param noOpen: any do not open quickfix window
+  quickfix = function(noOpen)
     local qf_items = {}
     for _, group in pairs(glance.list.groups) do
       for _, item in ipairs(group.items) do
@@ -340,7 +341,9 @@ Glance.actions = {
     end
     vim.fn.setqflist(qf_items, 'r')
     Glance.actions.close()
-    vim.cmd.copen()
+    if not noOpen then 
+      vim.cmd.copen()
+    end
   end,
   toggle_fold = function()
     glance:toggle_fold()


### PR DESCRIPTION
Minor QoL change: add a parameter to `actions.quickfix()`, allowing the user to suppress opening the quickfix window afterward.

The change is backwards compatible, meaning users who do not change their config will not experience any change in behavior of the quickfix function.