### PR TITLE
Added multiplier for darken / lighten amount

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ glance.setup({
   theme = { -- This feature might not work properly in nvim-0.7.2
     enable = true, -- Will generate colors for the plugin based on your current colorscheme
     mode = 'auto', -- 'brighten'|'darken'|'auto', 'auto' will set mode based on the brightness of your colorscheme
+    multiplier = 1, -- Darkens / brightens the generated colors by the given multiplier
   },
   mappings = {
     list = {

--- a/doc/glance.txt
+++ b/doc/glance.txt
@@ -101,6 +101,7 @@ The following is the default configuration:
       theme = { -- This feature might not work properly in nvim-0.7.2
         enable = true, -- Will generate colors for the plugin based on your current colorscheme
         mode = 'auto', -- 'brighten'|'darken'|'auto', 'auto' will set mode based on the brightness of your colorscheme
+        multiplier = 1, -- Darkens / brightens the generated colors by the given multiplier
       },
       mappings = {
         list = {

--- a/lua/glance/color.lua
+++ b/lua/glance/color.lua
@@ -1,4 +1,5 @@
 local utils = require('glance.utils')
+local config = require('glance.config')
 Color = {}
 Color.__index = Color
 
@@ -121,7 +122,7 @@ end
 
 function Color:darken(amount)
   local lab = self.lab
-  local l = lab[1] - (LAB.Kn * amount)
+  local l = lab[1] - (LAB.Kn * amount * config.multiplier)
   local r, g, b = lab2rgb(l, lab[2], lab[3])
   return Color.rgb2hex(r, g, b)
 end

--- a/lua/glance/config.lua
+++ b/lua/glance/config.lua
@@ -17,6 +17,7 @@ config.hl_ns = 'Glance'
 ---@class GlanceThemeOpts
 ---@field enable boolean
 ---@field mode ('"brighten"' | '"darken"' | '"auto"')
+---@field multiplier number
 
 ---@class GlanceMappingsOpts
 ---@field list table<string, fun()|false>
@@ -78,6 +79,7 @@ function config.setup(user_config, actions)
     theme = {
       enable = true,
       mode = 'auto',
+      multiplier = 1,
     },
     mappings = {
       list = {


### PR DESCRIPTION
I like that glance is able to generate a nicely looking color scheme for its popup. But I thought it would be nice if the generated colors could be darkened or brightened even more / less.

Therefore, I added a new option in the config that controls this. I'm way too dumb to understand the "color science" behind the generation, so there might be a better way to integrate this feature than just multiplying the amount 😅 