### PR TITLE
Feat: Support passing jump opts command from actions.jump

### DIFF
--- a/lua/glance/init.lua
+++ b/lua/glance/init.lua
@@ -297,8 +297,8 @@ Glance.actions = {
       end)
     end
   end,
-  jump = function()
-    glance:jump()
+  jump = function(opts)
+    glance:jump(opts)
   end,
   jump_vsplit = function()
     glance:jump({ cmd = 'vsplit' })

--- a/lua/glance/init.lua
+++ b/lua/glance/init.lua
@@ -446,7 +446,11 @@ function Glance:jump(opts)
   glance.push_tagstack()
 
   if opts.cmd then
-    vim.cmd(opts.cmd)
+    if type(opts.cmd) == 'function' then
+      opts.cmd(current_item)
+    else
+      vim.cmd(opts.cmd)
+    end
   end
 
   if vim.fn.buflisted(current_item.bufnr) == 1 then


### PR DESCRIPTION
This makes it possible for the user to create custom jump actions. Here's how I'm using it:

```lua
glance.setup {
  mappings = {
    list = {
      ['<M-w>'] = function()
        local win = require('window-picker').pick_window()
        if not win or not vim.api.nvim_win_is_valid(win) then
          return
        end
        actions.jump {
          cmd = function()
            vim.api.nvim_set_current_win(win)
          end,
        }
      end,
    }
  }
}
```

This lets you jump to the location in an existing window, picking the window using [nvim-window-picker](https://github.com/s1n7ax/nvim-window-picker).