### PR TITLE
Add vitual text at cursorline showing index/group/total

### DIFF
--- a/lua/glance/list.lua
+++ b/lua/glance/list.lua
@@ -371,12 +371,14 @@ local function get_lsp_method_label(method_name)
   return utils.capitalize(lsp.methods[method_name].label)
 end
 
+_G.Total_Count = 0
 function List:setup(opts)
   self.groups =
     process_locations(opts.results, opts.position_params, opts.offset_encoding)
   local group, location =
     find_starting_group_and_location(self.groups, opts.position_params)
 
+  _G.Total_Count = #opts.results
   folds.reset()
   folds.open(group.filename)
 


### PR DESCRIPTION

https://github.com/DNLHC/glance.nvim/assets/97848247/1342bd51-549f-4d70-915f-309295811bf3
With this change, I no longer need to look at right list.
If there is only one group, show index/total, otherwise, show index/group/total, from the screenshot above, you can see list cursorline disappears after winscroll, as I mentioned in https://github.com/DNLHC/glance.nvim/issues/70#issue-2178035949