### PR TITLE
Export is_open function within Glance

### DIFF
--- a/lua/glance/init.lua
+++ b/lua/glance/init.lua
@@ -569,4 +569,6 @@ end
 
 Glance.open = Glance.actions.open
 
+Glance.is_open = is_open
+
 return Glance


### PR DESCRIPTION
In the current version, we can only define the mappings at the setup level. I think this limits the potential of Glance.

It is very nice to have actions as an API for Glance actions. However, it's not flexible to use it since we don't have access to the is_open function.

With this simple PR, we will all be able to use Glance within custom logic.

My personal example:

```lua
local glance = require("glance")
local glance_actions = glance.actions

M.move_left = function()
  -- if Glance is open move to list if not move from neotree to buffer

  if glance.is_open() then
    glance_actions.enter_win('list')()
    return
  end

  local current_buf = vim.api.nvim_win_get_buf(0) -- Get current window's buffer
  local buf_name = vim.api.nvim_buf_get_name(current_buf) -- Get the name of the buffer

  if buf_name:match("neo%-tree") then
    vim.cmd("wincmd p")
  end
end

M.move_right = function()
  -- if Glance is open move to preview if not move from buffer to neotree

  if glance.is_open() then
    glance_actions.enter_win('preview')()
    return
  end

  vim.cmd("Neotree focus")
end
```
