### PR TITLE
fix(quickfix list): avoid clobbering existing lists

### DIFF
--- a/lua/glance/init.lua
+++ b/lua/glance/init.lua
@@ -392,7 +392,11 @@ Glance.actions = {
         })
       end
     end
-    vim.fn.setqflist(qf_items, 'r')
+    vim.fn.setqflist({}, ' ', {
+      items = qf_items,
+      nr = '$',
+      title = 'Glance',
+    })
     Glance.actions.close()
     if config.options.use_trouble_qf and pcall(require, 'trouble') then
       require('trouble').open('quickfix')


### PR DESCRIPTION
I've found a small issue with the quickfix list integration.

Setting the replace flag when sending Glance results into the quickfix list truncates existing results. That's a problem because the quickfix list keeps a history of all the lists generated during the session, and you can navigate the history with `:colder` and `:cnewer`. Which means that populating the list from glance.nvim hijacks whatever list spot we were displaying.

For example, imagine you have the lists in `:chistory`

| | order | title |
|--------|--------|--------|
| | 1 | grug-far results 1 |
| | 2 | grug-far results 2 |
| * | 3 | some other list |

Then you navigate back to see the second list with `:colder`.

| | order | title |
|--------|--------|--------|
| | 1 | grug-far results 1 |
| * | 2 | grug-far results 2 |
| | 3 | some other list |

Then you use Glance and send the results to the list:

| | order | title |
|--------|--------|--------|
| | 1 | grug-far results 1 |
| * | 2 | glance list |
| | 3 | some other list |

Now I've lost `grug-far results 2`.

Inserting a brand new entry seems like the desired behavior, not only prevents clobbering existing lists, but also helps you navigate previous glance results without opening the glance UI first.

---

I'm also adding a title to the newly inserted list, so we can display it in status lines or winbars.

https://github.com/user-attachments/assets/ab46d991-5b60-4c45-9821-03604c58b323


