### PR TITLE
Fix: `Cannot serialize function: type not supported` for nvim v0.11

### DIFF
--- a/lua/glance/lsp.lua
+++ b/lua/glance/lsp.lua
@@ -81,20 +81,7 @@ function M.setup()
   end
 end
 
-local function client_position_params(params)
-  local win = vim.api.nvim_get_current_win()
-
-  return function(client)
-    local ret = vim.lsp.util.make_position_params(win, client.offset_encoding)
-    return vim.tbl_extend('force', ret, params or {})
-  end
-end
-
 local function make_position_params(params)
-  if vim.fn.has('nvim-0.11') ~= 0 then
-    return client_position_params(params)
-  end
-
   local ret = vim.lsp.util.make_position_params(0)
   return vim.tbl_extend('force', ret, params or {})
 end


### PR DESCRIPTION

Hey, love the plugin. Thanks for all of the work you put into maintaining it! 😄

I encountered an error when executing `Glance definitions`

```
E5108: Error executing lua: vim/_editor.lua:431: nvim_exec2(): Vim:Error executing Lua callback: ...gram Files/Neovim/share/nvim/runtime/lua/vim/lsp/rpc.lua:291: Cannot serialise function: type not supported
stack traceback:
        [C]: in function 'encode'
        ...gram Files/Neovim/share/nvim/runtime/lua/vim/lsp/rpc.lua:291: in function 'encode_and_send'
        ...gram Files/Neovim/share/nvim/runtime/lua/vim/lsp/rpc.lua:338: in function 'request'
        ...m Files/Neovim/share/nvim/runtime/lua/vim/lsp/client.lua:679: in function 'request'
        C:/Program Files/Neovim/share/nvim/runtime/lua/vim/lsp.lua:879: in function 'buf_request'
        ...crand/Source/link00000000/glance.nvim/lua/glance/lsp.lua:9: in function 'handler'
        ...crand/Source/link00000000/glance.nvim/lua/glance/lsp.lua:106: in function 'request'
        ...rand/Source/link00000000/glance.nvim/lua/glance/init.lua:251: in function 'open'
        ...rand/Source/link00000000/glance.nvim/lua/glance/init.lua:378: in function 'open'
        .../crand/Source/link00000000/glance.nvim/plugin/glance.lua:5: in function <.../crand/Source/link00000000/glance.nvim/plugin/glance.lua:1>
        [C]: in function 'nvim_exec2'
        vim/_editor.lua:431: in function 'cmd'
        C:/Users/crand/AppData/Local/nvim/lua/plugins/lspconfig.lua:24: in function <C:/Users/crand/AppData/Local/nvim/lua/plugins/lspconfig.lua:24>
stack traceback:
        [C]: in function 'nvim_exec2'
        vim/_editor.lua:431: in function 'cmd'
        C:/Users/crand/AppData/Local/nvim/lua/plugins/lspconfig.lua:24: in function <C:/Users/crand/AppData/Local/nvim/lua/plugins/lspconfig.lua:24>
```

Looks like this was introduced in 4671f94372118e1659a7e71594d622719350389b which coincides with when I started noticing the issue.

```lua
local function client_position_params(params)
  local win = vim.api.nvim_get_current_win()

  return function(client)
    local ret = vim.lsp.util.make_position_params(win, client.offset_encoding)
    return vim.tbl_extend('force', ret, params or {})
  end
end

local function make_position_params(params)
  if vim.fn.has('nvim-0.11') ~= 0 then
    return client_position_params(params)
  end

  local ret = vim.lsp.util.make_position_params(0)
  return vim.tbl_extend('force', ret, params or {})
end
```

`client_position_params` is returning a function instead of a table which is causing this error. I removed the special handling for v0.11 and all seems to be working fine. I'm not sure what the intention was in returning a function here so let me know if there is any context I am missing.

Thanks!

Environment:

```
NVIM v0.11.0-dev-331+g033ea63b2
Build type: RelWithDebInfo
LuaJIT 2.1.1716656478
Run "nvim -V1 -v" for more info

---

OS Name	Microsoft Windows 11 Home
Version	10.0.22631 Build 22631
```
