### PR TITLE
fix: fix glance raise an error of invalid buf

### DIFF
--- a/lua/glance/init.lua
+++ b/lua/glance/init.lua
@@ -607,7 +607,9 @@ function Glance:close()
 end
 
 function Glance:destroy()
-  vim.api.nvim_buf_clear_namespace(self.parent_bufnr, layout_ns, 0, -1)
+  if vim.api.nvim_buf_is_valid(self.parent_bufnr) then
+    vim.api.nvim_buf_clear_namespace(self.parent_bufnr, layout_ns, 0, -1)
+  end
   self.list:destroy()
   self.preview:destroy()
   glance = {}


### PR DESCRIPTION
Open goto-preview.nvim floating window and then open glance reference list, and quit the glance at this time, goto-preview window will be closed, and glance's parent buf is invalid

error message:

```
E5108: Error executing lua: ...e/.local/share/nvim/lazy/glance.nvim/lua/glance/init.lua:610: Invalid buffer id: 5
stack traceback:
	[C]: in function 'nvim_buf_clear_namespace'
	...e/.local/share/nvim/lazy/glance.nvim/lua/glance/init.lua:610: in function 'destroy'
	...e/.local/share/nvim/lazy/glance.nvim/lua/glance/init.lua:301: in function <...e/.local/share/nvim/lazy/glance.nvim/lua/glance/init.lua:299>
```