### PR TITLE
fix: fix glance raise an error of invalid window (#84)

### DIFF
--- a/lua/glance/utils.lua
+++ b/lua/glance/utils.lua
@@ -7,10 +7,12 @@ function utils.create_push_tagstack(parent_winnr)
   local items = { { tagname = current_word, from = from } }
 
   return function()
-    vim.api.nvim_win_call(parent_winnr, function()
-      vim.cmd("norm! m'")
-      vim.fn.settagstack(parent_winnr, { items = items }, 't')
-    end)
+    if vim.api.nvim_win_is_valid(parent_winnr) then
+      vim.api.nvim_win_call(parent_winnr, function()
+        vim.cmd("norm! m'")
+        vim.fn.settagstack(parent_winnr, { items = items }, 't')
+      end)
+    end
   end
 end
 


### PR DESCRIPTION
Open goto-preview floating window and then open glance reference list, and open result in new tab, it will raise an error of invalid window.