### PR TITLE
Update GlancePreviewWinOpts type

### DIFF
--- a/lua/glance/config.lua
+++ b/lua/glance/config.lua
@@ -6,9 +6,9 @@ config.namespace = vim.api.nvim_create_namespace('Glance')
 config.hl_ns = 'Glance'
 
 ---@class GlancePreviewWinOpts
----@field enable boolean
----@field top_char string
----@field bottom_char string
+---@field cursorline boolean?
+---@field number boolean?
+---@field wrap boolean?
 
 ---@class GlanceListOpts
 ---@field position ('"left"' | '"right"')


### PR DESCRIPTION
It looks like the `enabled` field is no longer (?) utilized, and the rest of the properties are optional in them. The `top_char` and `bottom_char` were required as well, but it looks like they weren't used.