### PR TITLE
Correctly use vim.islist for Neovim 0.10+

### DIFF
--- a/lua/glance/lsp.lua
+++ b/lua/glance/lsp.lua
@@ -33,11 +33,10 @@ local function create_handler(method)
         else
           cancel_all_requests()
           result = (
-            vim.fn.has('nvim-0.10.0') == 1 and vim.islist(result)
-            or vim.tbl_islist(result)
-          )
-              and result
+            (vim.fn.has "nvim-0.10.0" == 1 and vim.islist or vim.tbl_islist)(result)
+            and result
             or { result }
+          )
 
           return cb(result, ctx)
         end


### PR DESCRIPTION
The previous version was right most cases, except when result _wasnt_ a list, in which case it would still call the deprecated fallback.

```lua
cond and func1() or func2()
```

This is because if func1 returns a falsey value, func2 will still be called.

This fix in #75 wasn't quite right