### PR TITLE
fix: vim.tbl_islist deprecation warning

### DIFF
--- a/lua/glance/lsp.lua
+++ b/lua/glance/lsp.lua
@@ -1,5 +1,7 @@
 local utils = require('glance.utils')
 
+local islist = vim.islist or vim.tbl_islist
+
 local M = {}
 
 local function create_handler(method)
@@ -32,12 +34,7 @@ local function create_handler(method)
           client_request_ids[ctx.client_id] = nil
         else
           cancel_all_requests()
-          result = (
-            vim.fn.has('nvim-0.10.0') == 1 and vim.islist(result)
-            or vim.tbl_islist(result)
-          )
-              and result
-            or { result }
+          result = islist(result) and result or { result }
 
           return cb(result, ctx)
         end

--- a/lua/glance/preview.lua
+++ b/lua/glance/preview.lua
@@ -164,7 +164,12 @@ function Preview:restore_win_opts()
   end
 end
 
-function Preview:close()
+---@param keep_buf boolean|nil
+function Preview:close(keep_buf)
+  if keep_buf == nil then
+    keep_buf = false
+  end
+
   self:on_detach_buffer((self.current_location or {}).bufnr)
   self:restore_win_opts()
 
@@ -180,7 +185,9 @@ function Preview:close()
       then
         vim.lsp.inlay_hint(bufnr, false)
       end
-      vim.api.nvim_buf_delete(bufnr, { force = true })
+      if not keep_buf then
+        vim.api.nvim_buf_delete(bufnr, { force = true })
+      end
     else
       clear_hl(bufnr)
     end

--- a/lua/glance/winbar.lua
+++ b/lua/glance/winbar.lua
@@ -24,10 +24,14 @@ function Winbar:render(section_values)
     return
   end
 
+  local winbar_escape = function(s)
+    return s:gsub("%%", "%%%%"):gsub("#", "##")
+  end
+
   local winbar_value = ''
   for section, value in pairs(section_values) do
     winbar_value =
-      string.format('%s%%#%s# %s', winbar_value, self.sections[section], value)
+      string.format('%s%%#%s# %s', winbar_value, self.sections[section], winbar_escape(value))
   end
 
   self.last_values = section_values


### PR DESCRIPTION
<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/3ced7eeb-b747-4331-abd4-7d41251551da" />

This patch will remove the warning message:
vim.tbl_islist is deprecated. Run ":checkhealth vim.deprecated" for more information

alternative to: https://github.com/DNLHC/glance.nvim/pull/91
