### PR TITLE
fix(winbar): clean winbar value input

### DIFF
--- a/lua/glance/winbar.lua
+++ b/lua/glance/winbar.lua
@@ -26,8 +26,12 @@ function Winbar:render(section_values)
 
   local winbar_value = ''
   for section, value in pairs(section_values) do
-    winbar_value =
-      string.format('%s%%#%s# %s', winbar_value, self.sections[section], value)
+    winbar_value = string.format(
+      '%s%%#%s# %s',
+      winbar_value,
+      self.sections[section],
+      tostring(value):gsub('%%', '%%%%')
+    )
   end
 
   self.last_values = section_values


### PR DESCRIPTION
Resolve issue with file names with characters that can break logic. Tried keeping diff smaller, not sure if we need to check for a value before doing the transform, or not like I have in personal patch https://github.com/khaneliman/khanelivim/commit/ab9164a926cd78ee82334ad141c51a1a20ba11e2

```
vim.schedule callback: ...k/myNeovimPackages/opt/glance.nvim/lua/glance/winbar.lua:0: E539: Illegal character <A>
stack traceback:
	[C]: in function 'nvim_win_set_option'
	...k/myNeovimPackages/opt/glance.nvim/lua/glance/winbar.lua: in function <...k/myNeovimPackages/opt/glance.nvim/lua/glance/winbar.lua:0>
```
Example currently (error thrown, no file name): 
<img width="1960" height="321" alt="image" src="https://github.com/user-attachments/assets/6ffa74b3-fb71-4ae8-8f36-2cf1e75a445c" />


Example value when patched: 
<img width="2018" height="386" alt="image" src="https://github.com/user-attachments/assets/cd48b6fb-5c45-4793-b031-776c09f97254" />
