### PR TITLE
Crash when fs_read returns nil for LSP file locations

### DIFF
--- a/lua/glance/list.lua
+++ b/lua/glance/list.lua
@@ -218,6 +218,11 @@ local function get_lines(bufnr, uri, rows)
   local data = vim.loop.fs_read(fd, stat.size, 0)
   vim.loop.fs_close(fd)
 
+  if data == nil then
+    vim.fn.bufload(bufnr)
+    return buf_lines()
+  end
+
   local lines = {} -- rows we need to retrieve
   local rows_needed = 0 -- keep track of how many unique rows we need
   for _, row in pairs(rows) do


### PR DESCRIPTION
Context:
happens with Helm/YAML LSP locations

Error:
```
  vim.schedule callback: ...v/.local/share/nvim/lazy/glance.nvim/lua/glance/list.lua:233: bad argument #1 to 'gmatch' (string expected, got nil)
  stack traceback:
        [C]: in function 'gmatch'
        ...v/.local/share/nvim/lazy/glance.nvim/lua/glance/list.lua:233: in function 'get_lines'
        ...v/.local/share/nvim/lazy/glance.nvim/lua/glance/list.lua:311: in function 'process_locations'
        ...v/.local/share/nvim/lazy/glance.nvim/lua/glance/list.lua:376: in function 'setup'
        ...v/.local/share/nvim/lazy/glance.nvim/lua/glance/list.lua:43: in function 'create'
        ...v/.local/share/nvim/lazy/glance.nvim/lua/glance/init.lua:476: in function 'create'
        ...v/.local/share/nvim/lazy/glance.nvim/lua/glance/init.lua:196: in function 'create'
        ...v/.local/share/nvim/lazy/glance.nvim/lua/glance/init.lua:296: in function 'open'
````

Cause:
`get_lines()` assumes `vim.loop.fs_read(fd, stat.size, 0)` always returns a string after `fs_open` succeeds

Proposed fix:
guard `data == nil` and fall back to `bufload(bufnr)` + `buf_lines()`